### PR TITLE
fix: Arreglar bug que no muestra 0 como resultado

### DIFF
--- a/Display.js
+++ b/Display.js
@@ -29,7 +29,7 @@ class Display {
     computar(tipo) {
         this.tipoOperacion !== 'igual' && this.calcular();
         this.tipoOperacion = tipo;
-        this.valorAnterior = this.valorActual || this.valorAnterior;
+        this.valorAnterior = this.valorActual.toString() || this.valorAnterior;
         this.valorActual = '';
         this.imprimirValores();
     }


### PR DESCRIPTION
Cuando valorActual es 0, no cumple la condición, por lo que toma valorAnterior y nunca se mostrara un 0 en el display.
valorActual se pasa a string para que pueda entrar en la condición, y así poder mostrar el 0 como resultado en el display.